### PR TITLE
fix to zenodo for peptide translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Annotations (gff): [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.744702.sv
 
 Table of one annotation name (best = sorted by e-value < 1e-05) by transcript ID (.csv): [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.775129.svg)](https://doi.org/10.5281/zenodo.775129)
 
-Peptide translations (fasta): [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.746294.svg)](https://doi.org/10.5281/zenodo.746294)
+Peptide translations (fasta): [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.257026.svg)](https://doi.org/10.5281/zenodo.257026)
 
 Expression quantification (salmon output): [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.257145.svg)](https://doi.org/10.5281/zenodo.257145)
 


### PR DESCRIPTION
For some reason, the doi/link (and button) for the peptide translations as shown: [https://doi.org/10.5281/zenodo.746294](https://doi.org/10.5281/zenodo.746294) redirects to the expression quantification [https://doi.org/10.5281/zenodo.257145](https://doi.org/10.5281/zenodo.257145).

I have no idea why, but [https://doi.org/10.5281/zenodo.257026](https://doi.org/10.5281/zenodo.257026) does make it to the peptide translations successfully...

Thanks for so meticulously keeping track of your code and data and, especially, for sharing it all.